### PR TITLE
Add German language support (fixes #1)

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Numera">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Numera.php
+++ b/src/Numera.php
@@ -13,6 +13,10 @@
 
 namespace Pino;
 
+use Pino\Strategy\DefaultNumberStrategy;
+use Pino\Strategy\GermanNumberStrategy;
+use Pino\Strategy\NumberStrategyInterface;
+
 class Numera
 {
     private $translations;
@@ -21,6 +25,8 @@ class Numera
     private string $locale;
 
     private bool $isCamelCase = false;
+
+    private NumberStrategyInterface $numberStrategy;
 
     public function __construct($locale = 'en', $localeFallback = 'en')
     {
@@ -34,11 +40,11 @@ class Numera
         return new static($lang, $defaultLang);
     }
 
-
     protected function loadTranslations($locale): void
     {
-        if (isset($this->translations[$locale]))
+        if (isset($this->translations[$locale])) {
             return;
+        }
 
         $path = __DIR__ . "/lang/{$locale}.php";
         $this->addTranslateFile($locale, $path);
@@ -61,7 +67,7 @@ class Numera
         return include __DIR__ . "/data/{$name}.php";
     }
 
-    protected function dataNumber($key)
+    public function dataNumber($key)
     {
         return $this->dataNumbers[$key] ?? null;
     }
@@ -76,83 +82,62 @@ class Numera
         return $this->translations[$this->locale] ?? $this->translations[$this->localeFallback];
     }
 
-    protected function translate($key, $default = null)
+    public function translate($key, $default = null, ?bool $camelCase = null)
     {
         $translations = $this->getLocaleTranslates();
         if (isset($translations[$key])) {
             $str = $translations[$key];
-        } else if (!str_contains($key, '_')) {
+        } elseif (!str_contains($key, '_')) {
             $str = $default;
         } else {
-            $subs = array_map(fn($sub) => $this->translate($sub, $default), explode('_', $key));
+            $subs = array_map(fn($sub) => $this->translate($sub, $default, $camelCase), explode('_', $key));
             $str = implode('{hundred_prefix}', $subs);
         }
-        if (!empty($str))
-            return $this->hasCamelCase() ? ucfirst($str) : $str;
-        else
+        if (empty($str)) {
             return $str;
+        }
+
+        $useCamelCase = $camelCase ?? $this->hasCamelCase();
+
+        return $useCamelCase ? ucfirst($str) : $str;
+    }
+
+    public function applyCamelCase(string $text): string
+    {
+        if (!$this->hasCamelCase()) {
+            return $text;
+        }
+
+        $parts = explode(' ', $text);
+
+        return implode(' ', array_map(fn($part) => ucfirst($part), $parts));
     }
 
     public function convertToWords($num)
     {
-        $num = str_replace(',', '', $num);
-        $num = intval(trim($num));
-        $units = $this->dataNumber('units');
-        $teens = $this->dataNumber('teens');
-        $tens = $this->dataNumber('tens');
-        $hundreds = $this->dataNumber('hundreds');
-        $thousands = $this->dataNumber('thousands');
+        $num = $this->normalizeInput($num);
 
-        if ($num < 10) {
-            return $this->translate($units[$num]);
-        } elseif ($num < 20) {
-            return $this->translate($teens[$num - 10]);
-        } elseif ($num < 100) {
-            return $this->translate($tens[(int)($num / 10)]) . ($num % 10 !== 0 ? '{ten}' . $this->translate($units[$num % 10]) : '');
-        } elseif ($num < 1000) {
-            return $this->translate($hundreds[(int)($num / 100)]) . ($num % 100 !== 0 ? '{hundred}' . $this->convertToWords($num % 100) : '');
-        } else {
-            $result = '';
-            for ($i = 0; $num > 0; $i++) {
-                $part = $num % 1000;
-                if ($part !== 0) {
-                    $result = $this->convertToWords($part) . '{thousand}' . $this->translate($thousands[$i]) . ($result ? '{part}' : '') . $result;
-                }
-                $num = (int)($num / 1000);
-            }
-
-            return $this->replaceSeparator($result);
-        }
+        return $this->numberStrategy->convertToWords($this, $num);
     }
 
     public function convertToSummary($num): string
     {
-        $thousands = $this->dataNumber('thousands');
-        $num = str_replace(',', '', $num);
-        $num = number_format($num);
-        $parts = explode(',', $num);
-        $count = count($parts) - 1;
-        $result = '';
-        foreach ($parts as $i => $part) {
-            $result .= $i === 0 ? $part . '{thousand}' . $this->translate($thousands[$count - $i]) : '{part}' . $part . '{thousand}' . $this->translate($thousands[$count - $i]);
-        }
-
-        return $this->replaceSeparator($result);
+        return $this->numberStrategy->convertToSummary($this, $num);
     }
 
     protected function getSeparators(): array
     {
-        $between = $this->translate('between');
+        $between = $this->translate('between', camelCase: false);
         return [
-            'thousand' => $this->translate('between.thousand', ' '),
-            'ten' => $this->translate('between.ten', '-'),
-            'hundred' => $this->translate('between.hundred', $between ?? ' '),
-            'part' => $this->translate('between.part', $between ?? ', '),
-            'hundred_prefix' => $this->translate('between.hundred.prefix', ' '),
+            'thousand' => $this->translate('between.thousand', ' ', camelCase: false),
+            'ten' => $this->translate('between.ten', '-', camelCase: false),
+            'hundred' => $this->translate('between.hundred', $between ?? ' ', camelCase: false),
+            'part' => $this->translate('between.part', $between ?? ', ', camelCase: false),
+            'hundred_prefix' => $this->translate('between.hundred.prefix', ' ', camelCase: false),
         ];
     }
 
-    protected function replaceSeparator($word)
+    public function replaceSeparator($word)
     {
         $separators = $this->getSeparators();
         $patterns = [];
@@ -163,10 +148,11 @@ class Numera
         return trim(preg_replace($patterns, $separators, $word));
     }
 
-    protected function getArrayBySeparator($word, string|array|null $separators = null): array
+    public function getArrayBySeparator($word, string|array|null $separators = null): array
     {
-        if (!empty($separators))
+        if (!empty($separators)) {
             $separators = is_array($separators) ? $separators : [$separators];
+        }
         $separators = array_merge(
             (array)$separators,
             $this->getSeparators(),
@@ -202,48 +188,25 @@ class Numera
 
     public function convertToNumber($words, string|array|null $separators = null)
     {
-        $translations = $this->getLocaleTranslates();
-        $translations = array_flip($translations);
-        $wordsArray = $this->getArrayBySeparator($words, $separators);
-        $number = 0;
-        $numbers = $this->dataNumber('numbers');
-        $tempNumber = 0;
+        return $this->numberStrategy->convertToNumber($this, $words, $separators);
+    }
 
-        foreach ($wordsArray as $word) {
-            $word = strtolower($word);
+    private function normalizeInput($num): int
+    {
+        $num = str_replace(['.', ',', ' '], '', (string)$num);
 
-            if (is_numeric($word)) {
-                $num = intval($word);
-            } else {
-                if (!isset($translations[strtolower($word)]))
-                    continue;
+        return (int)trim($num);
+    }
 
-                $word = $translations[$word];
-
-                if (!isset($numbers[$word]))
-                    continue;
-
-                $num = intval($numbers[$word]);
-            }
-
-
-            if ($word === 'hundred') {
-                $tempNumber = $tempNumber > 0 ? $tempNumber : 1;
-                $tempNumber = $tempNumber * $num;
-
-            } else if (in_array($word, ['thousand', 'million', 'billion', 'trillion', 'quadrillion', 'quintillion'])) {
-                $tempNumber = $tempNumber > 0 ? $tempNumber : 1;
-                $tempNumber = $tempNumber * $num;
-                $number += $tempNumber;
-                $tempNumber = 0;
-            } else {
-                $tempNumber += $num;
-            }
+    private function resolveNumberStrategy(string $locale): NumberStrategyInterface
+    {
+        $germanLocales = ['de', 'de-de', 'de-DE'];
+        if (in_array(strtolower($locale), array_map('strtolower', $germanLocales), true)
+            || str_starts_with(strtolower($locale), 'de')) {
+            return new GermanNumberStrategy();
         }
 
-        $number += $tempNumber;
-
-        return $number;
+        return new DefaultNumberStrategy();
     }
 
     /**
@@ -301,6 +264,7 @@ class Numera
     {
         $this->locale = $locale;
         $this->loadTranslations($locale);
+        $this->numberStrategy = $this->resolveNumberStrategy($locale);
 
         return $this;
     }

--- a/src/Strategy/DefaultNumberStrategy.php
+++ b/src/Strategy/DefaultNumberStrategy.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Pino\Strategy;
+
+use Pino\Numera;
+
+class DefaultNumberStrategy implements NumberStrategyInterface
+{
+    public function convertToWords(Numera $numera, int $num): string
+    {
+        $units = $numera->dataNumber('units');
+        $teens = $numera->dataNumber('teens');
+        $tens = $numera->dataNumber('tens');
+        $hundreds = $numera->dataNumber('hundreds');
+        $thousands = $numera->dataNumber('thousands');
+
+        if ($num < 10) {
+            return $numera->translate($units[$num]);
+        }
+        if ($num < 20) {
+            return $numera->translate($teens[$num - 10]);
+        }
+        if ($num < 100) {
+            return $numera->translate($tens[(int)($num / 10)])
+                . ($num % 10 !== 0 ? '{ten}' . $numera->translate($units[$num % 10]) : '');
+        }
+        if ($num < 1000) {
+            return $numera->translate($hundreds[(int)($num / 100)])
+                . ($num % 100 !== 0 ? '{hundred}' . $this->convertToWords($numera, $num % 100) : '');
+        }
+
+        $result = '';
+        for ($i = 0; $num > 0; $i++) {
+            $part = $num % 1000;
+            if ($part !== 0) {
+                $result = $this->convertToWords($numera, $part)
+                    . '{thousand}'
+                    . $numera->translate($thousands[$i])
+                    . ($result ? '{part}' : '')
+                    . $result;
+            }
+            $num = (int)($num / 1000);
+        }
+
+        return $numera->replaceSeparator($result);
+    }
+
+    public function convertToSummary(Numera $numera, int|string $num): string
+    {
+        $thousands = $numera->dataNumber('thousands');
+        $num = str_replace(',', '', (string)$num);
+        $num = number_format((int)$num);
+        $parts = explode(',', $num);
+        $count = count($parts) - 1;
+        $result = '';
+        foreach ($parts as $i => $part) {
+            $result .= $i === 0
+                ? $part . '{thousand}' . $numera->translate($thousands[$count - $i])
+                : '{part}' . $part . '{thousand}' . $numera->translate($thousands[$count - $i]);
+        }
+
+        return $numera->replaceSeparator($result);
+    }
+
+    public function convertToNumber(Numera $numera, string $words, string|array|null $separators = null): int
+    {
+        $translations = array_flip($numera->getLocaleTranslates());
+        $wordsArray = $numera->getArrayBySeparator($words, $separators);
+        $number = 0;
+        $numbers = $numera->dataNumber('numbers');
+        $tempNumber = 0;
+
+        foreach ($wordsArray as $word) {
+            $word = strtolower($word);
+
+            if (is_numeric($word)) {
+                $num = (int)$word;
+            } else {
+                if (!isset($translations[$word])) {
+                    continue;
+                }
+
+                $word = $translations[$word];
+
+                if (!isset($numbers[$word])) {
+                    continue;
+                }
+
+                $num = (int)$numbers[$word];
+            }
+
+            if ($word === 'hundred') {
+                $tempNumber = $tempNumber > 0 ? $tempNumber : 1;
+                $tempNumber *= $num;
+            } elseif (in_array($word, ['thousand', 'million', 'billion', 'trillion', 'quadrillion', 'quintillion'], true)) {
+                $tempNumber = $tempNumber > 0 ? $tempNumber : 1;
+                $tempNumber *= $num;
+                $number += $tempNumber;
+                $tempNumber = 0;
+            } else {
+                $tempNumber += $num;
+            }
+        }
+
+        return $number + $tempNumber;
+    }
+}

--- a/src/Strategy/GermanNumberStrategy.php
+++ b/src/Strategy/GermanNumberStrategy.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Pino\Strategy;
+
+use Pino\Numera;
+
+class GermanNumberStrategy implements NumberStrategyInterface
+{
+    public function convertToWords(Numera $numera, int $num): string
+    {
+        if ($num === 0) {
+            return $numera->translate('zero');
+        }
+
+        $thousands = $numera->dataNumber('thousands');
+        $result = '';
+        $i = 0;
+
+        while ($num > 0) {
+            $part = $num % 1000;
+            if ($part !== 0) {
+                $words = $this->convertUnder1000($numera, $part);
+                if ($i === 0) {
+                    $result = $words . $result;
+                } elseif ($i === 1) {
+                    $result = ($part === 1 ? 'ein' : $words) . 'tausend' . $result;
+                } else {
+                    $scale = $numera->translate($thousands[$i]);
+                    $result = $words . ' ' . $scale . ($result !== '' ? ' ' . $result : '');
+                }
+            }
+            $num = (int)($num / 1000);
+            $i++;
+        }
+
+        return $numera->applyCamelCase($result);
+    }
+
+    public function convertToSummary(Numera $numera, int|string $num): string
+    {
+        $num = $this->normalizeNumericInput($num);
+        $thousands = $numera->dataNumber('thousands');
+
+        if ($num === 0) {
+            return '0';
+        }
+
+        $parts = explode(',', number_format($num));
+        $groups = array_map('intval', $parts);
+
+        $scaleCount = count($groups) - 1;
+        $parts = [];
+        foreach ($groups as $i => $group) {
+            $scaleKey = $thousands[$scaleCount - $i];
+            if ($scaleKey === '') {
+                $parts[] = (string)$group;
+            } else {
+                $scaleLabel = $numera->translate($scaleKey, camelCase: false);
+                $parts[] = $group . ' ' . $scaleLabel;
+            }
+        }
+
+        return implode(', ', $parts);
+    }
+
+    public function convertToNumber(Numera $numera, string $words, string|array|null $separators = null): int
+    {
+        unset($separators);
+        $words = trim($words);
+        if ($words === '') {
+            return 0;
+        }
+
+        return $this->parsePhrase($numera, mb_strtolower($words));
+    }
+
+    private function parsePhrase(Numera $numera, string $phrase): int
+    {
+        $phrase = trim($phrase);
+        if ($phrase === '') {
+            return 0;
+        }
+
+        $scales = [
+            ['quintillion', 1000000000000000000],
+            ['quadrillion', 1000000000000000],
+            ['trillion', 1000000000000000000],
+            ['billion', 1000000000],
+            ['million', 1000000],
+        ];
+
+        foreach ($scales as [$scaleKey, $multiplier]) {
+            $label = mb_strtolower($numera->translate($scaleKey, camelCase: false));
+            $pattern = '/^(.+?)\s+' . preg_quote($label, '/') . '(?:\s+(.+))?$/u';
+            if (preg_match($pattern, $phrase, $matches)) {
+                $head = $this->parsePhrase($numera, $matches[1]);
+                $tail = isset($matches[2]) ? $this->parsePhrase($numera, $matches[2]) : 0;
+
+                return ($head * $multiplier) + $tail;
+            }
+        }
+
+        return $this->parseCompound($numera, $phrase);
+    }
+
+    private function convertUnder1000(Numera $numera, int $num): string
+    {
+        $units = $numera->dataNumber('units');
+        $teens = $numera->dataNumber('teens');
+        $tens = $numera->dataNumber('tens');
+        $hundreds = $numera->dataNumber('hundreds');
+
+        if ($num < 10) {
+            return $this->unitWord($numera, $num, standalone: true);
+        }
+        if ($num < 20) {
+            return $numera->translate($teens[$num - 10], camelCase: false);
+        }
+        if ($num < 100) {
+            $unit = $num % 10;
+            $ten = (int)($num / 10);
+            if ($unit === 0) {
+                return $numera->translate($tens[$ten], camelCase: false);
+            }
+
+            return $this->unitWord($numera, $unit)
+                . 'und'
+                . $numera->translate($tens[$ten], camelCase: false);
+        }
+
+        $hundred = (int)($num / 100);
+        $remainder = $num % 100;
+        $hundredWord = $numera->translate($hundreds[$hundred], camelCase: false);
+
+        if ($remainder === 0) {
+            return $hundredWord;
+        }
+
+        return $hundredWord . $this->convertUnder1000($numera, $remainder);
+    }
+
+    private function unitWord(Numera $numera, int $digit, bool $standalone = false): string
+    {
+        $units = $numera->dataNumber('units');
+        if ($digit === 1 && !$standalone) {
+            return 'ein';
+        }
+
+        return $numera->translate($units[$digit], camelCase: false);
+    }
+
+    private function normalizeNumericInput(int|string $num): int
+    {
+        $num = str_replace(['.', ',', ' '], '', (string)$num);
+
+        return (int)trim($num);
+    }
+
+    private function parseCompound(Numera $numera, string $word): int
+    {
+        $word = mb_strtolower(trim($word));
+        if ($word === '') {
+            return 0;
+        }
+
+        if (preg_match('/^(.*?)tausend(.*)$/u', $word, $matches)) {
+            $prefix = $matches[1];
+            $suffix = $matches[2];
+            $value = ($prefix === '' ? 1 : $this->parseUnder1000($numera, $prefix)) * 1000;
+
+            return $value + ($suffix === '' ? 0 : $this->parseUnder1000($numera, $suffix));
+        }
+
+        return $this->parseUnder1000($numera, $word);
+    }
+
+    private function parseUnder1000(Numera $numera, string $word): int
+    {
+        $word = mb_strtolower(trim($word));
+        if ($word === '') {
+            return 0;
+        }
+
+        if (preg_match('/^(.*?)hundert(.*)$/u', $word, $matches)) {
+            $prefix = $matches[1] === '' ? 1 : $this->parseUnder1000($numera, $matches[1]);
+            $suffix = $matches[2] === '' ? 0 : $this->parseUnder1000($numera, $matches[2]);
+
+            return ($prefix * 100) + $suffix;
+        }
+
+        $tens = $numera->dataNumber('tens');
+        foreach (array_slice($tens, 2) as $tenKey) {
+            $tenWord = $numera->translate($tenKey, camelCase: false);
+            if (str_ends_with($word, 'und' . $tenWord)) {
+                $unitPart = mb_substr($word, 0, mb_strlen($word) - mb_strlen('und' . $tenWord));
+
+                return $this->parseUnit($numera, $unitPart) + (int)$numera->dataNumber('numbers')[$tenKey];
+            }
+            if ($word === $tenWord) {
+                return (int)$numera->dataNumber('numbers')[$tenKey];
+            }
+        }
+
+        return $this->parseUnit($numera, $word);
+    }
+
+    private function parseUnit(Numera $numera, string $word): int
+    {
+        $word = mb_strtolower(trim($word));
+        if ($word === '' || $word === 'ein') {
+            return $word === 'ein' ? 1 : 0;
+        }
+
+        $translations = array_flip(array_map('mb_strtolower', $numera->getLocaleTranslates()));
+        $numbers = $numera->dataNumber('numbers');
+
+        if (!isset($translations[$word])) {
+            return 0;
+        }
+
+        $key = $translations[$word];
+
+        return (int)($numbers[$key] ?? 0);
+    }
+}

--- a/src/Strategy/NumberStrategyInterface.php
+++ b/src/Strategy/NumberStrategyInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Pino\Strategy;
+
+use Pino\Numera;
+
+interface NumberStrategyInterface
+{
+    public function convertToWords(Numera $numera, int $num): string;
+
+    public function convertToSummary(Numera $numera, int|string $num): string;
+
+    public function convertToNumber(Numera $numera, string $words, string|array|null $separators = null): int;
+}

--- a/src/lang/de-DE.php
+++ b/src/lang/de-DE.php
@@ -1,0 +1,3 @@
+<?php
+
+return include __DIR__ . '/de.php';

--- a/src/lang/de.php
+++ b/src/lang/de.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author   yoosefap
+ * @license  https://opensource.org/licenses/MIT MIT License
+ */
+
+
+return [
+    'zero' => 'null',
+    'one' => 'eins',
+    'two' => 'zwei',
+    'three' => 'drei',
+    'four' => 'vier',
+    'five' => 'fünf',
+    'six' => 'sechs',
+    'seven' => 'sieben',
+    'eight' => 'acht',
+    'nine' => 'neun',
+    'ten' => 'zehn',
+    'eleven' => 'elf',
+    'twelve' => 'zwölf',
+    'thirteen' => 'dreizehn',
+    'fourteen' => 'vierzehn',
+    'fifteen' => 'fünfzehn',
+    'sixteen' => 'sechzehn',
+    'seventeen' => 'siebzehn',
+    'eighteen' => 'achtzehn',
+    'nineteen' => 'neunzehn',
+    'twenty' => 'zwanzig',
+    'thirty' => 'dreißig',
+    'forty' => 'vierzig',
+    'fifty' => 'fünfzig',
+    'sixty' => 'sechzig',
+    'seventy' => 'siebzig',
+    'eighty' => 'achtzig',
+    'ninety' => 'neunzig',
+    'hundred' => 'hundert',
+    'one_hundred' => 'einhundert',
+    'two_hundred' => 'zweihundert',
+    'three_hundred' => 'dreihundert',
+    'four_hundred' => 'vierhundert',
+    'five_hundred' => 'fünfhundert',
+    'six_hundred' => 'sechshundert',
+    'seven_hundred' => 'siebenhundert',
+    'eight_hundred' => 'achthundert',
+    'nine_hundred' => 'neunhundert',
+    'thousand' => 'Tausend',
+    'million' => 'Millionen',
+    'billion' => 'Milliarden',
+    'trillion' => 'Billionen',
+    'quadrillion' => 'Billiarde',
+    'quintillion' => 'Trillion',
+];

--- a/tests/GermanTest.php
+++ b/tests/GermanTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @author   Pinoox
+ * @license  https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace Pino\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Pino\Numera;
+
+class GermanTest extends TestCase
+{
+    private function german(): Numera
+    {
+        return Numera::init('de');
+    }
+
+    public function testConvertLargeNumberToWords(): void
+    {
+        $result = $this->german()->convertToWords(4_454_545_156);
+        $this->assertEquals(
+            'vier Milliarden vierhundertvierundfünfzig Millionen fünfhundertfünfundvierzigtausendeinhundertsechsundfünfzig',
+            $result
+        );
+    }
+
+    #[DataProvider('germanNumericInputProvider')]
+    public function testConvertLargeNumberToWordsWithDotSeparator(int|string $input): void
+    {
+        $result = $this->german()->convertToWords($input);
+        $this->assertEquals(
+            'vier Milliarden vierhundertvierundfünfzig Millionen fünfhundertfünfundvierzigtausendeinhundertsechsundfünfzig',
+            $result
+        );
+    }
+
+    public static function germanNumericInputProvider(): array
+    {
+        return [
+            [4_454_545_156],
+            ['4.454.545.156'],
+        ];
+    }
+
+    public function testConvertLargeNumberToWordsCamelCase(): void
+    {
+        $result = $this->german()->setCamelCase(true)->convertToWords(4_454_545_156);
+        $this->assertEquals(
+            'Vier Milliarden Vierhundertvierundfünfzig Millionen Fünfhundertfünfundvierzigtausendeinhundertsechsundfünfzig',
+            $result
+        );
+    }
+
+    #[DataProvider('germanNumericInputProvider')]
+    public function testConvertLargeNumberToSummary(int|string $input): void
+    {
+        $result = $this->german()->convertToSummary($input);
+        $this->assertEquals(
+            '4 Milliarden, 454 Millionen, 545 Tausend, 156',
+            $result
+        );
+    }
+
+    public function testGermanTeensAndTens(): void
+    {
+        $n = $this->german();
+        $this->assertEquals('vierundfünfzig', $n->n2w(54));
+        $this->assertEquals('einundzwanzig', $n->n2w(21));
+        $this->assertEquals('zwanzig', $n->n2w(20));
+    }
+
+    public function testGermanThousandsConcatenation(): void
+    {
+        $n = $this->german();
+        $this->assertEquals('viertausend', $n->n2w(4000));
+        $this->assertEquals('eintausend', $n->n2w(1000));
+    }
+
+    public function testGermanHundredForms(): void
+    {
+        $n = $this->german();
+        $this->assertEquals('eins', $n->n2w(1));
+        $this->assertEquals('einhundert', $n->n2w(100));
+        $this->assertEquals('fünfhundertfünfundvierzigtausendeinhundertsechsundfünfzig', $n->n2w(545156));
+    }
+
+    public function testConvertWordsToNumber(): void
+    {
+        $result = $this->german()->convertToNumber(
+            'vier Milliarden vierhundertvierundfünfzig Millionen fünfhundertfünfundvierzigtausendeinhundertsechsundfünfzig'
+        );
+        $this->assertEquals(4_454_545_156, $result);
+    }
+
+    public function testConvertWordsToNumberCamelCase(): void
+    {
+        $result = $this->german()->setCamelCase(true)->convertToNumber(
+            'Vier Milliarden Vierhundertvierundfünfzig Millionen Fünfhundertfünfundvierzigtausendeinhundertsechsundfünfzig'
+        );
+        $this->assertEquals(4_454_545_156, $result);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds German (`de` / `de-DE`) locale with correct spelling rules: concatenation below millions, reversed tens with `und`, and `ein` vs `eins` in compounds.
- Introduces a strategy pattern (`DefaultNumberStrategy` / `GermanNumberStrategy`) so existing `en` and `fa` behavior stays unchanged.
- Adds `GermanTest` suite and `phpunit.xml` configuration.

Closes #1

## Test plan

- [x] Run `php vendor/bin/phpunit` (25 tests, all passing)
- [x] Verify `Numera::init('de')->n2w(4454545156)` output
- [x] Verify `n2s('4.454.545.156')` uses dot input and comma-separated summary
- [x] Verify `w2n()` round-trip for spaced German phrases